### PR TITLE
chore: bump provider version

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -19,7 +19,7 @@ type HoneycombPlugin struct {
 
 func NewHoneycombPlugin() schema.MachComposerPlugin {
 	state := &HoneycombPlugin{
-		provider:    "0.15.1", // Provider version of `honeycombio/honeycombio`
+		provider:    "0.18.1", // Provider version of `honeycombio/honeycombio`
 		siteConfigs: map[string]*HoneycombConfig{},
 	}
 	return plugin.NewPlugin(&schema.PluginSchema{


### PR DESCRIPTION
- Bump honeycomb/honeycomb provider version (https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs)
- Current version isn't a published version ![image](https://github.com/mach-composer/mach-composer-plugin-honeycomb/assets/117137592/0836efdc-a08b-4573-8cc8-6f03d715e08a)
